### PR TITLE
make clear dynamic branching only in dev version

### DIFF
--- a/dynamic.Rmd
+++ b/dynamic.Rmd
@@ -18,7 +18,7 @@ With [static branching](#static) (explained in the [following chapter](#static))
 3. The [graph visualizations](#visuals) are too slow, too cumbersome, and too unresponsive when the number of static targets is large.
 4. [static branching](#static) relies on metaprogramming and code manipulation, which makes it difficult to use and understand.
 
-[Dynamic branching](#dynamic), supported in versions above 7.7.0, solves these problems.
+[Dynamic branching](#dynamic), supported in (development) versions above 7.7.0, solves these problems.
 
 ## Which kind of branching should I use?
 


### PR DESCRIPTION
The current CRAN 'r-release' v 7.7.0 does not have dynamic branching and this is the version many users would install. Led to a little bit of head scratching when running the code in the example didn't do what the book showed it did!

# Summary

Proposed change to text of the book to distinguish between r-release & r-devel

# Related GitHub issues and pull requests

None

# Checklist

- [ X] I understand and agree to this repository's [code of conduct](https://github.com/ropensci/drake-manual/blob/master/CODE_OF_CONDUCT.md).
- [ X] I have listed any substantial changes in the [development news](https://github.com/ropenscilabs/drake-manual/blob/master/NEWS.md).
- [X ] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
