### PR TITLE
Fix broken link to HPC template files

### DIFF
--- a/hpc.Rmd
+++ b/hpc.Rmd
@@ -138,7 +138,7 @@ Set the [`clustermq`](https://github.com/mschubert/clustermq) global options to 
 options(clustermq.scheduler = "slurm", clustermq.template = "slurm_clustermq.tmpl")
 ```
 
-Here, `slurm_clustermq.tmpl` is a [template file](https://github.com/ropensci/drake/tree/master/inst/hpc_template_files) with configuration details. Use `drake_hpc_template_file()` to write one of the available examples.
+Here, `slurm_clustermq.tmpl` is a [template file](https://github.com/ropensci/drake/tree/master/inst/templates/hpc) with configuration details. Use `drake_hpc_template_file()` to write one of the available examples.
 
 ```{r, eval = FALSE}
 drake_hpc_template_file("slurm_clustermq.tmpl") # Write the file slurm_clustermq.tmpl.


### PR DESCRIPTION
# Summary

Reading through the manual, clicked on a link, and found it to be broken. I found the correct link and have replaced it here.

# Related GitHub issues and pull requests

- Ref: N/A

# Checklist

- [x] I understand and agree to this repository's [code of conduct](https://github.com/ropensci/drake-manual/blob/master/CODE_OF_CONDUCT.md).
- [ ] I have listed any substantial changes in the [development news](https://github.com/ropenscilabs/drake-manual/blob/master/NEWS.md).
- [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
