### PR TITLE
Fix typos

### DIFF
--- a/triggers.Rmd
+++ b/triggers.Rmd
@@ -72,7 +72,7 @@ make(plan, trigger = trigger(command = FALSE, depend = FALSE, file = FALSE))
 make(plan, trigger = trigger(command = FALSE, depend = FALSE, file = FALSE))
 ```
 
-Interestingly, `psi_2` now depends on `psi_1`. Since `psi_1` is part of the because of the **condition** trigger, it needs to be up to date before we attempt `psi_2`. However, since `psi_1` is not part of the command, changing it will not trip the other triggers such as **depend**.
+Interestingly, `psi_2` now depends on `psi_1`. Since `psi_1` is part of the target `psi_2` because of the **condition** trigger, it needs to be up to date before we attempt `psi_2`. However, since `psi_1` is not part of the command, changing it will not trip the other triggers such as **depend**.
 
 ```{r}
 vis_drake_graph(plan)
@@ -157,7 +157,7 @@ drake_plan(
 
 Sometimes, you may want to suppress a target without having to worry about turning off every single trigger. That is why the `trigger()` function has a `mode` argument, which controls the role of the **condition** trigger in the decision to build or skip a target. The available trigger modes are `"whitelist"` (default), `"blacklist"`, and `"condition"`.
 
-- `trigger(mode = "whitelist")`: we *rebuild* the target whenever `condition` evaluates to `TRUE`. Otherwise, we defer to the other triggers. This is the default behaviro described above in this chapter.
+- `trigger(mode = "whitelist")`: we *rebuild* the target whenever `condition` evaluates to `TRUE`. Otherwise, we defer to the other triggers. This is the default behavior described above in this chapter.
 - `trigger(mode = "blacklist")`: we *skip* the target whenever `condition` evaluates to `FALSE`. Otherwise, we defer to the other triggers.
 - `trigger(mode = "condition")`: here, the `condition` trigger is the only decider, and we ignore all the other triggers. We *rebuild* target whenever `condition` evaluates to `TRUE` and *skip* it whenever `condition` evaluates to `FALSE`.
 


### PR DESCRIPTION
# Summary

Fixed typo in line 160, and attempted to insert what I thought was missing in line 75.

# Checklist

- [x] I understand and agree to this repository's [code of conduct](https://github.com/ropensci/drake-manual/blob/master/CODE_OF_CONDUCT.md).
- [ ] I have listed any substantial changes in the [development news](https://github.com/ropenscilabs/drake-manual/blob/master/NEWS.md).
- [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
