### PR TITLE
Fixed typo

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -93,7 +93,7 @@ When it comes time to actually rerun the entire project, you have much more conf
 clean()    # Remove the original author's results.
 make(plan) # Independently re-create the results from the code and input data.
 ```
-a
+
 #### Independent replication
 
 With even more evidence and confidence, you can invest the time to independently replicate the original code base if necessary. Up until this point, you relied on basic `drake` functions such as `make()`, so you may not have needed to peek at any substantive author-defined code in advance. In that case, you can stay usefully ignorant as you reimplement the original author's methodology. In other words, `drake` could potentially improve the integrity of independent replication.


### PR DESCRIPTION
Deleted character that was stopping the 'Independent replication' heading from displaying correctly