### PR TITLE
add r_make example

### DIFF
--- a/hpc.Rmd
+++ b/hpc.Rmd
@@ -376,6 +376,19 @@ make(plan)
 readd(x)
 ```
 
+If you happen to be using `r_make` and want to use parallelism _within_ targets, `future::plan(future.callr::callr)` needs to go inside `_drake.R` before the call to `drake_config()`. In that case your  `_drake.R` file would look like this:
+
+```{r, eval = FALSE}
+plan <- drake_plan(
+       x = furrr::future_map_int(1:2, function(x) Sys.getpid()),
+       y = furrr::future_map_int(1:2, function(x) Sys.getpid())
+     )
+     
+future::plan(future.callr::callr)
+
+drake_config(plan)
+```
+This will allow you to call `r_make` like normal.
 
 #### Persistent workers
 

--- a/hpc.Rmd
+++ b/hpc.Rmd
@@ -376,7 +376,7 @@ make(plan)
 readd(x)
 ```
 
-If you happen to be using `r_make` and want to use parallelism _within_ targets, `future::plan(future.callr::callr)` needs to go inside `_drake.R` before the call to `drake_config()`. In that case your  `_drake.R` file would look like this:
+If you happen to be using `r_make()` and want to use parallelism _within_ targets, `future::plan(future.callr::callr)` needs to go inside `_drake.R` before the call to `drake_config()`. In that case your  `_drake.R` file would look like this:
 
 ```{r, eval = FALSE}
 plan <- drake_plan(
@@ -388,7 +388,7 @@ future::plan(future.callr::callr)
 
 drake_config(plan)
 ```
-This will allow you to call `r_make` like normal.
+This will allow you to call `r_make` like normal. Configuring your `_drake.R` file like this is necessary because `r_make()` launches an external R process that runs `_drake.R` followed by `make()`. See [this section](https://books.ropensci.org/drake/projects.html#safer-interactivity) for more information on `r_make()`.
 
 #### Persistent workers
 


### PR DESCRIPTION
# Summary

Offered to provide an example of using `r_make` for within target parallelization.  

# Checklist

- [x] I understand and agree to this repository's [code of conduct](https://github.com/ropensci/drake-manual/blob/master/CODE_OF_CONDUCT.md).
- [ ] I have listed any substantial changes in the [development news](https://github.com/ropenscilabs/drake-manual/blob/master/NEWS.md).
- [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
