### PR TITLE
r_make() vs. make()

### DIFF
--- a/debugging.Rmd
+++ b/debugging.Rmd
@@ -226,7 +226,7 @@ From the data frame above, `regression1_small` is outdated because an R object d
 
 ### Strategies to prevent unexpected changes in the future
 
-`drake` is sensitive to changing functions in your global environment, and this sensitivity can invalidate targets unexpectedly. Whenever you plan to run `make()`, it is always best to restart your R session and load your packages and functions into a fresh clean workspace. [`r_make()`](https://docs.ropensci.org/drake/reference/r_make.html) does all this cleaning and prep work for you automatically, and it is more robust and dependable  (and childproofed) than ordinary `r_make()`. To read more, visit <https://books.ropensci.org/drake/projects#safer-interactivity>.
+`drake` is sensitive to changing functions in your global environment, and this sensitivity can invalidate targets unexpectedly. Whenever you plan to run `make()`, it is always best to restart your R session and load your packages and functions into a fresh clean workspace. [`r_make()`](https://docs.ropensci.org/drake/reference/r_make.html) does all this cleaning and prep work for you automatically, and it is more robust and dependable  (and childproofed) than ordinary `make()`. To read more, visit <https://books.ropensci.org/drake/projects#safer-interactivity>.
 
 ## More help
 


### PR DESCRIPTION
# Summary

Compare `r_make()` to `make()`.

# Related GitHub issues and pull requests

Minor typo.

# Checklist

- [x] I understand and agree to this repository's [code of conduct](https://github.com/ropensci/drake-manual/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have listed any substantial changes in the [development news](https://github.com/ropenscilabs/drake-manual/blob/main/NEWS.md).
- [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
